### PR TITLE
Feature/notice 공지사항 수정 기능 및 이미지 업로드 

### DIFF
--- a/src/main/java/com/bank/controller/NoticeController.java
+++ b/src/main/java/com/bank/controller/NoticeController.java
@@ -1,19 +1,37 @@
 package com.bank.controller;
 
-import java.util.ArrayList;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
 import java.util.List;
+import java.util.Map;
+import java.util.UUID;
 
+import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
+import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.multipart.MultipartFile;
 
 import com.bank.service.NoticeService;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Size;
+
 import com.bank.dto.NoticeDTO;
 import com.bank.dto.PageDTO;
+import com.bank.dto.RequestNoticeDTO;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -25,7 +43,8 @@ public class NoticeController {
 	
 	private final NoticeService noticeService;
 
-// 공지사항 상세 페이지
+
+	// 공지사항 상세 페이지
 	@GetMapping("/notice-page/{noticeId}")
 	public String getNoticeDetail(
 			Model model, 
@@ -35,7 +54,6 @@ public class NoticeController {
 		log.info("noticeId:{}", noticeId);
 		
 		List<NoticeDTO> list = noticeService.getNoticeById(noticeId);
-		
 		
 		
 		List<NoticeDTO> mainNotices = list.stream().filter((notice)-> notice.getId().equals(noticeId)).toList();
@@ -51,7 +69,7 @@ public class NoticeController {
 		return "notice-detail-page";
 	}
 	
-//	공지사항 메인 페이지
+	//공지사항 메인 페이지
 	@GetMapping("/notice-page")
 	public String getNotices(
 	        Model model, 
@@ -93,8 +111,40 @@ public class NoticeController {
 	    
 	    return "notice-page";
 	}
-// 공지사항 삭제
-	@DeleteMapping("/notice-page/{noticeId}")
+	
+	// 공지사항 쓰기 페이지
+	@GetMapping("/notice-editor-page")
+	public String getNoticeEditor(Model model) {
+		 model.addAttribute("RequestNoticeDTO", new RequestNoticeDTO()); // DTO 객체 추가
+		return "notice-editor-page";
+	}
+	
+	
+	/*============== CRUD ================ */
+	
+	// 공지사항 추가
+	@PostMapping("/notices/submit")
+	public String addNotice(
+	        @ModelAttribute("RequestNoticeDTO") @Valid RequestNoticeDTO requestNoticeDTO, 
+	        BindingResult result, 
+	        Model model) {
+		
+		if(result.hasErrors()) {
+			return "notice-editor-page";
+		}
+		
+		requestNoticeDTO.setUserId(-999L);
+		noticeService.addNotice(requestNoticeDTO);
+		
+		model.addAttribute("success","정상적으로 추가되었습니다.");
+		model.addAttribute("page",1);
+		model.addAttribute("pageSize",5);
+		
+		return "redirect:/notice-page?page=1&pageSize=5";
+	}
+
+	// 공지사항 삭제
+	@DeleteMapping("/notices/{noticeId}")
 	public ResponseEntity<String> deleteNotice(@PathVariable Long noticeId) {
 		
 		log.info("id: {}",noticeId);
@@ -104,5 +154,19 @@ public class NoticeController {
 		} else {
 			 return ResponseEntity.status(400).body("삭제 실패: 존재하지 않는 게시글 ID 입니다.");
 		}
+	}
+	
+
+	
+	// 공지사항 이미지 업로드
+	@PostMapping("/notices/image-upload")
+	public ResponseEntity<?> uploadImage(
+			@RequestParam MultipartFile file
+			) throws IOException{
+		log.info("업로드된 파일: {}", file.getOriginalFilename());
+
+		String fileUrl = noticeService.upload(file);
+	    
+	    return ResponseEntity.ok().body(Map.of("url", fileUrl, "message", "파일을 성공적으로 업로드 하였습니다."));
 	}
 }

--- a/src/main/java/com/bank/controller/NoticeController.java
+++ b/src/main/java/com/bank/controller/NoticeController.java
@@ -18,6 +18,7 @@ import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -30,6 +31,7 @@ import jakarta.validation.Valid;
 import jakarta.validation.constraints.Size;
 
 import com.bank.dto.NoticeDTO;
+import com.bank.dto.NoticeViewsDTO;
 import com.bank.dto.PageDTO;
 import com.bank.dto.RequestNoticeDTO;
 
@@ -115,8 +117,32 @@ public class NoticeController {
 	// 공지사항 쓰기 페이지
 	@GetMapping("/notice-editor-page")
 	public String getNoticeEditor(Model model) {
-		 model.addAttribute("RequestNoticeDTO", new RequestNoticeDTO()); // DTO 객체 추가
+		model.addAttribute("RequestNoticeDTO", new RequestNoticeDTO()); // DTO 객체 추가
 		return "notice-editor-page";
+	}
+	
+	// 공지사항 수정 페이지
+	@GetMapping("/notice-update-page/{id}")
+	public String getNoticeUpdateEditor(
+			@PathVariable Long id,
+			Model model
+			) {
+			
+		List<NoticeDTO> noticeDTOs = noticeService.getNoticeById(id);
+		NoticeDTO noticeDTO = noticeDTOs.stream().filter((notice)-> notice.getId() == id).toList().get(0);
+		
+		RequestNoticeDTO initialNotice = RequestNoticeDTO.builder()
+			.id(noticeDTO.getId())
+			.title(noticeDTO.getTitle())
+			.contents(noticeDTO.getContents())
+			.build();
+		
+		log.info("contents:{}", noticeDTO.getContents());
+		RequestNoticeDTO requestNoticeDTO = new RequestNoticeDTO();
+		requestNoticeDTO.setId(noticeDTO.getId());
+		model.addAttribute("RequestNoticeDTO", requestNoticeDTO); // DTO 객체 추가
+		model.addAttribute("oldNotice", initialNotice);
+		return "notice-update-page";
 	}
 	
 	
@@ -142,6 +168,29 @@ public class NoticeController {
 		
 		return "redirect:/notice-page?page=1&pageSize=5";
 	}
+	
+	// 공지사항 수정
+	@PostMapping("/notices/update-submit/{id}")
+	public String updateNotice(
+			@PathVariable Long id,
+	        @ModelAttribute("RequestNoticeDTO") @Valid RequestNoticeDTO requestNoticeDTO, 
+	        BindingResult result, 
+	        Model model) {
+		
+		if(result.hasErrors()) {
+			return "notice-update-page";
+		}
+		
+		requestNoticeDTO.setUserId(-999L);
+		requestNoticeDTO.setId(id);
+		noticeService.updateNotice(requestNoticeDTO);
+		
+		model.addAttribute("success","정상적으로 수정 되었습니다.");
+		model.addAttribute("page",1);
+		model.addAttribute("pageSize",5);
+		
+		return "redirect:/notice-page?page=1&pageSize=5";
+	}
 
 	// 공지사항 삭제
 	@DeleteMapping("/notices/{noticeId}")
@@ -157,7 +206,6 @@ public class NoticeController {
 	}
 	
 
-	
 	// 공지사항 이미지 업로드
 	@PostMapping("/notices/image-upload")
 	public ResponseEntity<?> uploadImage(
@@ -168,5 +216,18 @@ public class NoticeController {
 		String fileUrl = noticeService.upload(file);
 	    
 	    return ResponseEntity.ok().body(Map.of("url", fileUrl, "message", "파일을 성공적으로 업로드 하였습니다."));
+	}
+	
+	// 조회수 증가
+	@PatchMapping("/notices/views/{id}")
+	public String updateViews(@RequestParam Long id) {
+		
+		 int views = noticeService.getViews(id);
+		 NoticeViewsDTO noticeViewsDTO = new NoticeViewsDTO(id, (long) views);
+		 
+		 noticeService.updateViews(noticeViewsDTO);
+		 
+		 return null;
+		
 	}
 }

--- a/src/main/java/com/bank/dto/NoticeViewsDTO.java
+++ b/src/main/java/com/bank/dto/NoticeViewsDTO.java
@@ -1,0 +1,13 @@
+package com.bank.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class NoticeViewsDTO {
+	private Long id;
+	private Long views;
+}

--- a/src/main/java/com/bank/dto/RequestNoticeDTO.java
+++ b/src/main/java/com/bank/dto/RequestNoticeDTO.java
@@ -1,0 +1,22 @@
+package com.bank.dto;
+
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class RequestNoticeDTO {
+	
+	@Size(min=3, max=50, message = "제목은 최소 3자 이상 50자 이하이어야 합니다.")
+	private String title;
+	@Size(min=3, max=5000, message = "내용은 최소 3자 이상 5000자 이하이어야 합니다.")
+	private String contents;
+	private Long userId;
+}

--- a/src/main/java/com/bank/dto/RequestNoticeDTO.java
+++ b/src/main/java/com/bank/dto/RequestNoticeDTO.java
@@ -13,7 +13,7 @@ import lombok.Setter;
 @NoArgsConstructor
 @Builder
 public class RequestNoticeDTO {
-	
+	private Long id;
 	@Size(min=3, max=50, message = "제목은 최소 3자 이상 50자 이하이어야 합니다.")
 	private String title;
 	@Size(min=3, max=5000, message = "내용은 최소 3자 이상 5000자 이하이어야 합니다.")

--- a/src/main/java/com/bank/mapper/NoticeMapper.java
+++ b/src/main/java/com/bank/mapper/NoticeMapper.java
@@ -8,6 +8,7 @@ import org.apache.ibatis.session.RowBounds;
 
 import com.bank.dto.MemberDTO;
 import com.bank.dto.NoticeDTO;
+import com.bank.dto.NoticeViewsDTO;
 import com.bank.dto.RequestNoticeDTO;
 
 
@@ -19,5 +20,8 @@ public interface NoticeMapper {
 	public List<NoticeDTO> getNoticeById(Long id);
 	public int deleteById(Long id);
 	public int addNotice(RequestNoticeDTO requestNoticeDTO);
+	public int updateNotice(RequestNoticeDTO requestNoticeDTO);
+	public int updateViews(NoticeViewsDTO noticeViewsDTO);
+	public int getViews(Long id);
 	
 }

--- a/src/main/java/com/bank/mapper/NoticeMapper.java
+++ b/src/main/java/com/bank/mapper/NoticeMapper.java
@@ -8,6 +8,7 @@ import org.apache.ibatis.session.RowBounds;
 
 import com.bank.dto.MemberDTO;
 import com.bank.dto.NoticeDTO;
+import com.bank.dto.RequestNoticeDTO;
 
 
 @Mapper
@@ -17,5 +18,6 @@ public interface NoticeMapper {
 	public int getNoticeCount();
 	public List<NoticeDTO> getNoticeById(Long id);
 	public int deleteById(Long id);
+	public int addNotice(RequestNoticeDTO requestNoticeDTO);
 	
 }

--- a/src/main/java/com/bank/mapper/NoticeMapper.xml
+++ b/src/main/java/com/bank/mapper/NoticeMapper.xml
@@ -69,9 +69,31 @@ UNION ALL
 	VALUES(#{title}, #{contents}, #{userId}, 0)
 </insert>
 
+<!-- 공지사항 수정 -->
+<update id="updateNotice" parameterType="RequestNoticeDTO">
+	UPDATE notices 
+	SET title = #{title}, contents = #{contents}
+	WHERE user_id = #{userId} AND id = #{id}
+</update>
+
+
+
 <!-- 공지사항 삭제 -->
 <delete id="deleteById" parameterType="long">
 	DELETE FROM notices n WHERE n.id=#{id}
 </delete>
+
+<!-- 공지사항 조회카운트 수정 -->
+<update id="updateViews" parameterType="NoticeViewsDTO">
+	UPDATE notices 
+	SET views = #{views}
+	WHERE id = #{id}
+</update>
+
+<!-- 공지사항 조회카운트 조회 -->
+<select id="getViews" parameterType="long" resultType="int">
+	SELECT views from notices
+	WHERE id = #{id}
+</select>
 	
 </mapper>

--- a/src/main/java/com/bank/mapper/NoticeMapper.xml
+++ b/src/main/java/com/bank/mapper/NoticeMapper.xml
@@ -16,6 +16,7 @@
     </association>
 </resultMap>
 	
+<!-- 공지사항 목록 조회(페이징) -->	
 <select id="getNotices" parameterType="string" resultMap="NoticeResultMap">
     SELECT n.id, n.title, n.contents, DATE_FORMAT(n.created_at, '%Y.%m.%d %H:%i:%S') as created_at, n.views,
            u.id AS userid, u.username
@@ -24,6 +25,7 @@
     ORDER BY n.id DESC
 </select>
 
+<!-- 공지사항 상세 페이지 | 이전, 현재, 이후 게시글 정보 조회 -->
 <select id="getNoticeById" parameterType="long" resultMap="NoticeResultMap">
 (
     SELECT n.id, n.title, n.contents, DATE_FORMAT(n.created_at, '%Y.%m.%d %H:%i:%S') AS created_at, 
@@ -55,10 +57,17 @@ UNION ALL
 
 </select>
 
+
+<!-- 공지사항 전체 개수 -->
 <select id="getNoticeCount" resultType="int">
     SELECT COUNT(*) FROM notices 
 </select>
 
+<!-- 공지사항 추가 -->
+<insert id="addNotice">
+	INSERT INTO notices(title, contents, user_id, views)
+	VALUES(#{title}, #{contents}, #{userId}, 0)
+</insert>
 
 <!-- 공지사항 삭제 -->
 <delete id="deleteById" parameterType="long">

--- a/src/main/java/com/bank/service/NoticeService.java
+++ b/src/main/java/com/bank/service/NoticeService.java
@@ -1,12 +1,18 @@
 package com.bank.service;
 
+import java.io.IOException;
 import java.util.List;
 
+import org.springframework.web.multipart.MultipartFile;
+
 import com.bank.dto.NoticeDTO;
+import com.bank.dto.RequestNoticeDTO;
 
 public interface NoticeService {
 	public int getNoticeCount();
 	public List<NoticeDTO> getNotices(int page, int pageSize);
 	public List<NoticeDTO> getNoticeById(Long id);
 	public int deleteById(Long id);
+	public int addNotice(RequestNoticeDTO requestNoticeDTO);
+	public String upload(MultipartFile file) throws IOException;
 }

--- a/src/main/java/com/bank/service/NoticeService.java
+++ b/src/main/java/com/bank/service/NoticeService.java
@@ -6,6 +6,7 @@ import java.util.List;
 import org.springframework.web.multipart.MultipartFile;
 
 import com.bank.dto.NoticeDTO;
+import com.bank.dto.NoticeViewsDTO;
 import com.bank.dto.RequestNoticeDTO;
 
 public interface NoticeService {
@@ -15,4 +16,7 @@ public interface NoticeService {
 	public int deleteById(Long id);
 	public int addNotice(RequestNoticeDTO requestNoticeDTO);
 	public String upload(MultipartFile file) throws IOException;
+	public int getViews(long id);
+	public int updateViews(NoticeViewsDTO noticeViewsDTO);
+	public int updateNotice(RequestNoticeDTO requestNoticeDTO);
 }

--- a/src/main/java/com/bank/service/NoticeServiceImpl.java
+++ b/src/main/java/com/bank/service/NoticeServiceImpl.java
@@ -1,19 +1,31 @@
 package com.bank.service;
 
 
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
 import java.util.List;
+import java.util.UUID;
 
 import org.apache.ibatis.session.RowBounds;
 import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
 
+import com.bank.controller.NoticeController;
 import com.bank.dto.NoticeDTO;
+import com.bank.dto.RequestNoticeDTO;
 import com.bank.mapper.NoticeMapper;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
 import com.bank.exception.ResourceNotFoundHandler;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class NoticeServiceImpl implements NoticeService {
 	
 	private final NoticeMapper noticeMapper;
@@ -44,6 +56,31 @@ public class NoticeServiceImpl implements NoticeService {
 	@Override
 	public int deleteById(Long id) {
 		return noticeMapper.deleteById(id);
+	}
+
+	@Override
+	public int addNotice(RequestNoticeDTO requestNoticeDTO) {
+		return noticeMapper.addNotice(requestNoticeDTO);
+	}
+	
+	@Override
+	public String upload(MultipartFile file) throws IOException {
+	    // 1. 파일 저장 경로 설정
+	    final String UPLOAD_DIR = "C:/upload/images"; // 운영 환경에 맞게 변경
+	    Files.createDirectories(Paths.get(UPLOAD_DIR)); // 디렉토리 없으면 생성
+
+	    // 2. 파일명 변환 (UUID 추가, 확장자 유지)
+	    String originalFileName = file.getOriginalFilename();
+	    String extension = originalFileName.substring(originalFileName.lastIndexOf("."));
+	    String newFileName = UUID.randomUUID().toString() + extension;
+
+	    // 3. 파일 저장
+	    Path filePath = Path.of(UPLOAD_DIR, newFileName);
+	    Files.copy(file.getInputStream(), filePath, StandardCopyOption.REPLACE_EXISTING);
+
+	    // 4. DB에 저장할 경로 반환
+	    return "/assets/images/upload/" + newFileName;
+	    
 	}
 	
 }

--- a/src/main/java/com/bank/service/NoticeServiceImpl.java
+++ b/src/main/java/com/bank/service/NoticeServiceImpl.java
@@ -15,6 +15,7 @@ import org.springframework.web.multipart.MultipartFile;
 
 import com.bank.controller.NoticeController;
 import com.bank.dto.NoticeDTO;
+import com.bank.dto.NoticeViewsDTO;
 import com.bank.dto.RequestNoticeDTO;
 import com.bank.mapper.NoticeMapper;
 
@@ -82,5 +83,19 @@ public class NoticeServiceImpl implements NoticeService {
 	    return "/assets/images/upload/" + newFileName;
 	    
 	}
-	
+
+	@Override
+	public int getViews(long id) {
+		return noticeMapper.getViews(id);
+	}
+
+	@Override
+	public int updateNotice(RequestNoticeDTO requestNoticeDTO) {
+		return noticeMapper.updateNotice(requestNoticeDTO);
+	}
+
+	@Override
+	public int updateViews(NoticeViewsDTO noticeViewsDTO) {
+		return noticeMapper.updateViews(noticeViewsDTO);
+	}
 }

--- a/src/main/resources/META-INF/resources/WEB-INF/views/notice-editor-page.jsp
+++ b/src/main/resources/META-INF/resources/WEB-INF/views/notice-editor-page.jsp
@@ -1,0 +1,12 @@
+<%@ page language="java" contentType="text/html; charset=UTF-8"
+    pageEncoding="UTF-8"%>
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="UTF-8">
+<title>SBank | 글쓰기</title>
+</head>
+<body>
+	<jsp:include page="notice/notice-editor-form.jsp" flush="true"/>
+</body>
+</html>

--- a/src/main/resources/META-INF/resources/WEB-INF/views/notice-update-page.jsp
+++ b/src/main/resources/META-INF/resources/WEB-INF/views/notice-update-page.jsp
@@ -1,0 +1,12 @@
+<%@ page language="java" contentType="text/html; charset=UTF-8"
+    pageEncoding="UTF-8"%>
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="UTF-8">
+<title>SBank | 수정하기</title>
+</head>
+<body>
+	<jsp:include page="notice/notice-update-form.jsp" flush="true"/>
+</body>
+</html>

--- a/src/main/resources/META-INF/resources/WEB-INF/views/notice/notice-detail.jsp
+++ b/src/main/resources/META-INF/resources/WEB-INF/views/notice/notice-detail.jsp
@@ -14,7 +14,7 @@
             background-color: white;
             border-radius: 20px;
             box-shadow: 0 2px 4px rgba(0,0,0,0.1);
-            overflow: hidden;
+            overflow: hidden auto;
             max-height:800px;
             height:100%;
         }
@@ -224,7 +224,7 @@ $(document).ready(function () {
 		if(isDelete){
 	    $.ajax({
 	        type : 'DELETE',
-	        url : '/notice-page/'+e.target.dataset.id ,
+	        url : '/notices/'+e.target.dataset.id ,
 	        success: function(result){
 					alert("삭제 되었습니다.")
 					location.replace("/notice-page?page=1&pageSize=5");

--- a/src/main/resources/META-INF/resources/WEB-INF/views/notice/notice-detail.jsp
+++ b/src/main/resources/META-INF/resources/WEB-INF/views/notice/notice-detail.jsp
@@ -198,7 +198,9 @@
                 	<a href="/notice-page?page=${page}&pageSize=${pageSize}">목록</a>
                 </button>
                 <div>
-                    <button class="btn btn-modify">수정</button>
+                    <button class="btn btn-modify">
+                    	<a href="/notice-update-page/${mainNotice.id}">수정</a>
+                    </button>
                     <button class="btn btn-delete" data-id="${mainNotice.id}">삭제</button>
                 </div>
             </div>

--- a/src/main/resources/META-INF/resources/WEB-INF/views/notice/notice-editor-form.jsp
+++ b/src/main/resources/META-INF/resources/WEB-INF/views/notice/notice-editor-form.jsp
@@ -1,0 +1,213 @@
+<%@ page language="java" contentType="text/html; charset=UTF-8"
+    pageEncoding="UTF-8"%>
+ <%@ taglib prefix="form" uri="http://www.springframework.org/tags/form" %>
+	<!DOCTYPE html>
+	<html>
+	<head>
+	<meta charset="UTF-8">
+ 	<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/summernote@0.9.0/dist/summernote.min.css">
+    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/3.4.1/css/bootstrap.min.css">
+    <meta name="contextPath" content="${pageContext.request.contextPath}">
+    <style>
+    
+    body {
+  		  display: flex;
+		  flex-direction: column;
+		  width: 100%;
+		  height: 100vh;
+		  justify-content: space-around;
+		  background-color: #1a365d;
+		}
+		
+		li {
+		  list-style: none;
+		}
+		
+		a {
+		  text-decoration: none;
+		  color: black;
+		}
+		
+		header {
+		  height: 60px;
+		  padding: 10px 40px 10px 40px;
+		  width: 100%;
+		  background: transparent;
+		  display: flex;
+		  justify-content: space-between;
+		  align-items: center;
+		  
+		}
+		
+		header h1 a {
+		  display: flex;
+		  align-items: center;
+		    color:white;
+		}
+		
+		header .brand-icon {
+		  width: 30px;
+		  height: 30px;
+		  background: white;
+		  margin-right: 8px;
+		}
+		
+		.navlist-group {
+		  display: flex;
+		}
+		
+		.navlist-group li {
+		  padding: 0 1rem 3px 1rem;
+		}
+		
+		.navlist-group li:hover{
+			box-shadow:0 1px 0 0 white;
+		}
+		
+		.navlist-group li a:active{
+			color: #1054B4;
+		}
+		
+		.navlist-group li a {
+			color:white;
+		}
+    
+  
+		#notice-form {
+		  display: flex;
+		  flex-direction: column;
+		  justify-content: flex-start;
+		  max-width: 1200px;
+		  width: 100%;
+		  background: white;
+		  padding: 40px;
+		  border-radius: 20px;
+		  margin: 2rem auto;
+		}
+		
+		#notice-form .note-editor {
+		  border-radius: 0px;
+		}
+		.notice-title-input {
+		  padding: 5px;
+		  width: 100%;
+		  height: 50px;
+		  border: none;
+		  outline: none;
+		  font-size: 1.85rem;
+		  font-weight: bold;
+		}
+		
+		.btn {
+		  padding: 10px 20px;
+		  border: none;
+		  border-radius: 4px;
+		  cursor: pointer;
+		  font-size: 14px;
+		  margin: 0 5px;
+		}
+		
+		.button-group {
+		  width: 100%;
+		  display: flex;
+		  justify-content: space-between;
+		}
+		.btn-submit {
+		  background-color: #1a365d;
+		  color: white;
+		}
+		
+		.btn-submit:hover {
+		  background-color: #1054b4;
+		  color: white;
+		}
+		
+		.btn-back:hover {
+		  background-color: #d7d7d7;
+}
+    </style>
+</head>
+<body>
+	<form:form 
+		modelAttribute="RequestNoticeDTO" 
+		id="notice-form"
+		action="/notices/submit" 
+		method="post">
+	  <div>
+	    <form:input 
+	    	class="notice-title-input" 
+	    	placeholder="제목을 입력해주세요." 
+	    	type="text" 
+	    	path="title"/>
+	    <form:errors style="color:red; margin-bottom:1rem; display:inline-block; padding-left:5px" path="title"/>
+	  </div>
+	   	<form:textarea id="summernote" path="contents"/>
+	  	<form:errors style="color:red; margin-bottom:1rem" path="contents"/> 	
+	  <div class="button-group">
+	    <button class="btn btn-submit" type="submit">등록</button>
+	    <button class="btn btn-back" type="button">나가기</button>
+	  </div>
+	</form:form>
+</body>
+    <!-- JavaScript -->
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.6.0/jquery.min.js"></script>
+    <script src="https://stackpath.bootstrapcdn.com/bootstrap/3.4.1/js/bootstrap.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/summernote@0.9.0/dist/summernote.min.js"></script>
+    <script>
+    //  https://summernote.org/deep-dive/#insertnode
+        $(document).ready(function () {
+        	const contextPath = document.querySelector("meta[name='contextPath']").getAttribute("content");
+        	
+        	const backBtn = document.querySelector(".btn-back");
+        	
+        	backBtn.addEventListener("click",()=>{
+        		window.history.back();
+        	})
+            
+
+            $("#summernote").summernote({
+                placeholder: "공지할 내용을 입력해주세요.",
+                height: 500,
+                focus: true,
+                toolbar: [
+                    ["fontsize", ["fontsize"]],
+                    ["style", ["bold", "italic", "underline", "strikethrough", "clear"]],
+                    ["color", ["color"]],
+                    ["table", ["table"]],
+                    ["para", ["ul", "ol", "paragraph"]],
+                    ["height", ["height"]],
+                    ["insert", ["picture"]]
+                ],
+                lang: "ko-KR",
+                callbacks: {
+                    onImageUpload: function (files) {
+                        Array.from(files).forEach(imageUploader);
+                    }
+                }
+            });
+
+            function imageUploader(file) {
+                const formData = new FormData();
+                formData.append("file", file);
+
+                $.ajax({
+                    data: formData,
+                    type: "POST",
+                    url: "/notices/image-upload",
+                    enctype: "multipart/form-data",
+                    processData: false,
+                    contentType: false,
+                    success: function (data) {
+                        $("#summernote").summernote("insertImage", contextPath + data.url, function ($image) {
+                            $image.css("width", "100%");
+                        });
+                        console.log(data);
+                    },
+                    error: function (xhr, status, error) {
+                        console.error("이미지 업로드 실패:", error);
+                    }
+                });
+            }
+        });
+    </script>
+</html>

--- a/src/main/resources/META-INF/resources/WEB-INF/views/notice/notice-main.jsp
+++ b/src/main/resources/META-INF/resources/WEB-INF/views/notice/notice-main.jsp
@@ -132,11 +132,13 @@
                     </tr>
                 </thead>
                 <tbody>
+            
                 	<c:forEach
                 		var="notice"
                 		items="${notices}"
                 	>
 	                	<tr>
+	                	  
 	                        <td>${notice.id}</td>
 	                        <td class="title-cell"><a href="/notice-page/${notice.id}?page=${pageInfo.page}&pageSize=${pageInfo.pageSize}">${notice.title}</a></td>
 	                        <td>${notice.admin.username}</td>
@@ -144,10 +146,13 @@
 	                        <td class="view-cell">${notice.views} </td>
 	                    </tr>
                 	</c:forEach>
+                	<c:if test="${empty notices}">
+                 		<p class="text-align:center">공지사항이 존재하지 않습니다.</p>
+                     </c:if>
                 </tbody>
             </table>
             <button class="write-btn">
-            	<a href="/notice-write-form">글쓰기</a>
+            	<a href="/notice-editor-page">글쓰기</a>
             </button>
             <div class="pagination">
 	            <c:if test="${pageInfo.page>1}">

--- a/src/main/resources/META-INF/resources/WEB-INF/views/notice/notice-update-form.jsp
+++ b/src/main/resources/META-INF/resources/WEB-INF/views/notice/notice-update-form.jsp
@@ -1,0 +1,221 @@
+<%@ page language="java" contentType="text/html; charset=UTF-8"
+    pageEncoding="UTF-8"%>
+ <%@ taglib prefix="form" uri="http://www.springframework.org/tags/form" %>
+	<!DOCTYPE html>
+	<html>
+	<head>
+	<meta charset="UTF-8">
+ 	<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/summernote@0.9.0/dist/summernote.min.css">
+    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/3.4.1/css/bootstrap.min.css">
+    <meta name="contextPath" content="${pageContext.request.contextPath}">
+    <style>
+    
+    body {
+  		  display: flex;
+		  flex-direction: column;
+		  width: 100%;
+		  height: 100vh;
+		  justify-content: space-around;
+		  background-color: #1a365d;
+		}
+		
+		li {
+		  list-style: none;
+		}
+		
+		a {
+		  text-decoration: none;
+		  color: black;
+		}
+		
+		header {
+		  height: 60px;
+		  padding: 10px 40px 10px 40px;
+		  width: 100%;
+		  background: transparent;
+		  display: flex;
+		  justify-content: space-between;
+		  align-items: center;
+		  
+		}
+		
+		header h1 a {
+		  display: flex;
+		  align-items: center;
+		    color:white;
+		}
+		
+		header .brand-icon {
+		  width: 30px;
+		  height: 30px;
+		  background: white;
+		  margin-right: 8px;
+		}
+		
+		.navlist-group {
+		  display: flex;
+		}
+		
+		.navlist-group li {
+		  padding: 0 1rem 3px 1rem;
+		}
+		
+		.navlist-group li:hover{
+			box-shadow:0 1px 0 0 white;
+		}
+		
+		.navlist-group li a:active{
+			color: #1054B4;
+		}
+		
+		.navlist-group li a {
+			color:white;
+		}
+    
+  
+		#notice-form {
+		  display: flex;
+		  flex-direction: column;
+		  justify-content: flex-start;
+		  max-width: 1200px;
+		  width: 100%;
+		  background: white;
+		  padding: 40px;
+		  border-radius: 20px;
+		  margin: 2rem auto;
+		}
+		
+		#notice-form .note-editor {
+		  border-radius: 0px;
+		}
+		.notice-title-input {
+		  padding: 5px;
+		  width: 100%;
+		  height: 50px;
+		  border: none;
+		  outline: none;
+		  font-size: 1.85rem;
+		  font-weight: bold;
+		}
+		
+		.btn {
+		  padding: 10px 20px;
+		  border: none;
+		  border-radius: 4px;
+		  cursor: pointer;
+		  font-size: 14px;
+		  margin: 0 5px;
+		}
+		
+		.button-group {
+		  width: 100%;
+		  display: flex;
+		  justify-content: space-between;
+		}
+		.btn-submit {
+		  background-color: #1a365d;
+		  color: white;
+		}
+		
+		.btn-submit:hover {
+		  background-color: #1054b4;
+		  color: white;
+		}
+		
+		.btn-back:hover {
+		  background-color: #d7d7d7;
+}
+    </style>
+</head>
+<body>
+	<form:form 
+		modelAttribute="RequestNoticeDTO" 
+		id="notice-form"
+		action="/notices/update-submit/${oldNotice.id}" 
+		method="post">
+	  <div>
+	    <form:input 
+	    	class="notice-title-input" 
+	    	placeholder="제목을 입력해주세요." 
+	    	value="${oldNotice.title}"
+	    	type="text" 
+	    	path="title"/>
+	    <form:errors style="color:red; margin-bottom:1rem; display:inline-block; padding-left:5px" path="title"/>
+	  </div>
+	   	<form:textarea id="summernote" path="contents"/>
+	  	<form:errors style="color:red; margin-bottom:1rem" path="contents"/> 	
+	  <div class="button-group">
+	    <button class="btn btn-submit" type="submit">등록</button>
+	    <button class="btn btn-back" type="button">나가기</button>
+	  </div>
+	</form:form>
+</body>
+    <!-- JavaScript -->
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.6.0/jquery.min.js"></script>
+    <script src="https://stackpath.bootstrapcdn.com/bootstrap/3.4.1/js/bootstrap.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/summernote@0.9.0/dist/summernote.min.js"></script>
+    <script>
+    //  https://summernote.org/deep-dive/#insertnode
+        $(document).ready(function () {
+        	const contextPath = document.querySelector("meta[name='contextPath']").getAttribute("content");
+        	
+        	const backBtn = document.querySelector(".btn-back");
+        	
+        	backBtn.addEventListener("click",()=>{
+        		window.history.back();
+        	})
+            
+
+            $("#summernote").summernote({
+                placeholder: "공지할 내용을 입력해주세요.",
+                height: 500,
+                focus: true,
+                toolbar: [
+                    ["fontsize", ["fontsize"]],
+                    ["style", ["bold", "italic", "underline", "strikethrough", "clear"]],
+                    ["color", ["color"]],
+                    ["table", ["table"]],
+                    ["para", ["ul", "ol", "paragraph"]],
+                    ["height", ["height"]],
+                    ["insert", ["picture"]]
+                ],
+                lang: "ko-KR",
+                callbacks: {
+                    onImageUpload: function (files) {
+                        Array.from(files).forEach(imageUploader);
+                    }
+                }
+            });
+        	
+            // JSP에서 전달한 초기값을 Summernote에 설정
+            const initialContent =`${oldNotice.contents}`; // 모델에서 contents 값 가져와서 설정
+            $('#summernote').summernote('code', initialContent); // Summernote에 초기값 설정
+
+            
+            function imageUploader(file) {
+                const formData = new FormData();
+                formData.append("file", file);
+
+                $.ajax({
+                    data: formData,
+                    type: "POST",
+                    url: "/notices/image-upload",
+                    enctype: "multipart/form-data",
+                    processData: false,
+                    contentType: false,
+                    success: function (data) {
+                        $("#summernote").summernote("insertImage", contextPath + data.url, function ($image) {
+                            $image.css("width", "100%");
+                        });
+                        console.log(data);
+                    },
+                    error: function (xhr, status, error) {
+                        console.error("이미지 업로드 실패:", error);
+                    }
+                });
+            }
+            
+
+        });
+    </script>
+</html>

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -5,6 +5,9 @@ server.port=8090
 spring.mvc.view.prefix=/WEB-INF/views/
 spring.mvc.view.suffix=.jsp
 
+# 정적 리소스 경로 지정: /assets/images/upload/에 접근하면 C:/upload/images/에서 파일을 찾는다.
+spring.web.resources.static-locations=file:///C:/upload/images/
+spring.mvc.static-path-pattern=/assets/images/upload/**
 
 
 # DB 연동


### PR DESCRIPTION
## 추가된 것
- 이미지 업로드 기능
  - 사용자 이미지 업로드  → 로컬의 특정 경로에 이미지 저장  →  해당 이미지가 저장된 주소를 문자열로 응답 → 응답된 이미지를 <img src=""/> 로 바인딩하여 즉시 삽입
  - 위에서 이미지 태그로 변환하여 삽입하는 처리는 summernote 에디터 라이브러리에서 지원하는 메서드로 처리
- 공지사항 게시판 수정 기능 추가
- 기존 jsp form 데이터 방식에서  Spring Form Tag 를 적용한 form 바인딩 방식으로 변경
  - 사용법은 [링크1](https://youngwan2.notion.site/1-19668acd779b806eb999e014931516c8) 와 [링크2](https://youngwan2.notion.site/2-DTO-BindingResult-19668acd779b807ea5efdf4ef7cc1c1a )  참고
```bash
<%@ taglib uri="http://www.springframework.org/tags/form" prefix="form" %>
```

## 참고 이미지
- 공지사항 메인
![image](https://github.com/user-attachments/assets/8ed7167d-23f9-4de9-bec4-d4c9f68c12c0)

- 공지사항 상세
 - 상단
![image](https://github.com/user-attachments/assets/549f234a-6507-4360-be0a-4a1cc70bc2ca)
 - 하단
![image](https://github.com/user-attachments/assets/a2838a2e-5544-4fbc-97b3-640530a165b3)

- 공지사항 수정
  -  수정 전
![image](https://github.com/user-attachments/assets/1cb381e2-375d-4b09-be50-4ff9f2128b59)
  -  수정 후
![image](https://github.com/user-attachments/assets/f8ec2d0d-44a3-439b-b0ab-71246c98aa74)
